### PR TITLE
Bitmap byte endianness and subsection area consideration bugfix.

### DIFF
--- a/src/Shipwreck.Phash.Bitmaps/BitmapExtensions.cs
+++ b/src/Shipwreck.Phash.Bitmaps/BitmapExtensions.cs
@@ -57,9 +57,9 @@ namespace Shipwreck.Phash.Bitmaps
                     for (var dx = 0; dx < r.Width; dx++)
                     {
                         Vector3 sv;
-                        sv.Z = data[i++]; // R
+                        sv.Z = data[i++]; // B
                         sv.Y = data[i++]; // G
-                        sv.X = data[i++]; // B
+                        sv.X = data[i++]; // R
 
                         r[dx, dy] = (byte)(((int)(Vector3.Dot(yc, sv) + 128) >> 8) + 16);
                     }
@@ -132,9 +132,9 @@ namespace Shipwreck.Phash.Bitmaps
             return bs;
         }
 
-        public static Bitmap ToBitmap(this Image image)
+        public static Bitmap ToBitmap(this Image image, PixelFormat format = PixelFormat.DontCare)
         {
-            var bitmap = new Bitmap(image.Width, image.Height, image.PixelFormat);
+            var bitmap = new Bitmap(image.Width, image.Height, format == PixelFormat.DontCare ? image.PixelFormat : format);
             try
             {
                 bitmap.SetResolution(image.HorizontalResolution, image.VerticalResolution);

--- a/src/Shipwreck.Phash.Bitmaps/RawBitmapData.cs
+++ b/src/Shipwreck.Phash.Bitmaps/RawBitmapData.cs
@@ -148,9 +148,9 @@ namespace Shipwreck.Phash.Bitmaps
 
             public override void ExtractPixelBytesToColor(byte[] rawBytes, int startIndex, ref int A, ref int R, ref int G, ref int B)
             {
-                R = rawBytes[startIndex];
+                B = rawBytes[startIndex];
                 G = rawBytes[startIndex + 1];
-                B = rawBytes[startIndex + 2];
+                R = rawBytes[startIndex + 2];
             }
         }
 
@@ -161,10 +161,10 @@ namespace Shipwreck.Phash.Bitmaps
 
             public override void ExtractPixelBytesToColor(byte[] rawBytes, int startIndex, ref int A, ref int R, ref int G, ref int B)
             {
-                A = rawBytes[startIndex];
-                R = rawBytes[startIndex + 1];
-                G = rawBytes[startIndex + 2];
-                B = rawBytes[startIndex + 3];
+                B = rawBytes[startIndex];
+                G = rawBytes[startIndex + 1];
+                R = rawBytes[startIndex + 2];
+                A = rawBytes[startIndex + 3];
             }
         }
 
@@ -175,10 +175,10 @@ namespace Shipwreck.Phash.Bitmaps
 
             public override void ExtractPixelBytesToColor(byte[] rawBytes, int startIndex, ref int A, ref int R, ref int G, ref int B)
             {
-                A = rawBytes[startIndex];
-                R = rawBytes[startIndex + 1];
-                G = rawBytes[startIndex + 2];
-                B = rawBytes[startIndex + 3];
+                B = rawBytes[startIndex];
+                G = rawBytes[startIndex + 1];
+                R = rawBytes[startIndex + 2];
+                A = rawBytes[startIndex + 3];
             }
         }
 
@@ -189,9 +189,9 @@ namespace Shipwreck.Phash.Bitmaps
 
             public override void ExtractPixelBytesToColor(byte[] rawBytes, int startIndex, ref int A, ref int R, ref int G, ref int B)
             {
-                R = rawBytes[startIndex];
+                B = rawBytes[startIndex];
                 G = rawBytes[startIndex + 1];
-                B = rawBytes[startIndex + 2];
+                R = rawBytes[startIndex + 2];
             }
         }
     }

--- a/src/Shipwreck.Phash.Bitmaps/RawBitmapDataExtensions.cs
+++ b/src/Shipwreck.Phash.Bitmaps/RawBitmapDataExtensions.cs
@@ -41,15 +41,15 @@ namespace Shipwreck.Phash.Bitmaps
 
             var data = rawBitmapData1ByteComponent;
 
-            var r = new ByteImage(rawBitmapData1ByteComponent.PixelWidth, rawBitmapData1ByteComponent.PixelHeight);
+            var r = new ByteImage(area.Width, area.Height);
             var yc = new Vector3(66, 129, 25);
 
             rawBitmapData1ByteComponent.PerPixelInArea(area, (dx, dy, A, R, G, B) =>
             {
                 Vector3 sv;
-                sv.Z = R;
+                sv.Z = B;
                 sv.Y = G;
-                sv.X = B;
+                sv.X = R;
 
                 r[dx, dy] = (byte)(((int)(Vector3.Dot(yc, sv) + 128) >> 8) + 16);
             });

--- a/src/Shipwreck.Phash.Bitmaps/Shipwreck.Phash.Bitmaps.csproj
+++ b/src/Shipwreck.Phash.Bitmaps/Shipwreck.Phash.Bitmaps.csproj
@@ -4,14 +4,14 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>shipwreck.jp</Authors>
     <Company />
     <Product>priHash</Product>
     <Description>C# Implementation of phash-0.9.4 for bitmaps.</Description>
     <PackageLicenseUrl>http://www.gnu.org/licenses/</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/pgrho/phash</PackageProjectUrl>
-    <FileVersion>0.1.0.0</FileVersion>
+    <FileVersion>0.1.1.0</FileVersion>
     <Copyright>Copyright © 2016 shipwreck.jp</Copyright>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Shipwreck.Phash/Shipwreck.Phash.csproj
+++ b/src/Shipwreck.Phash/Shipwreck.Phash.csproj
@@ -5,14 +5,14 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>shipwreck.jp</Authors>
     <Company />
     <Product>priHash</Product>
     <Description>C# Implementation of phash-0.9.4.</Description>
     <PackageLicenseUrl>http://www.gnu.org/licenses/</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/pgrho/phash</PackageProjectUrl>
-    <FileVersion>0.1.0.0</FileVersion>
+    <FileVersion>0.1.1.0</FileVersion>
     <Copyright>Copyright © 2016 shipwreck.jp</Copyright>
   </PropertyGroup>
 


### PR DESCRIPTION
After using the library I discovered these two bugs and a possible bug in the base algorithm as outlined in #5. I figured these would be useful before delving into the issue more.